### PR TITLE
do not pass blank string to big decimal

### DIFF
--- a/lib/money/distributed/storage.rb
+++ b/lib/money/distributed/storage.rb
@@ -80,6 +80,8 @@ class Money
       def retrieve_rates
         @redis.exec do |r|
           r.hgetall(REDIS_KEY).each_with_object(@cache) do |(key, val), h|
+            next if val.nil? || val == ''
+
             h[key] = BigDecimal(val)
           end
         end


### PR DESCRIPTION
the open exchange rates API returned a blank string for a few currencies sometimes.
Do not allow passing a blank string to `BigDecimal`, which will fail.