### PR TITLE
Ruby 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
 services:
   - redis-server
 before_install: gem install bundler

--- a/lib/money/distributed/version.rb
+++ b/lib/money/distributed/version.rb
@@ -2,6 +2,6 @@
 
 class Money
   module Distributed
-    VERSION = '0.0.3'
+    VERSION = '0.0.4'
   end
 end

--- a/money-distributed.gemspec
+++ b/money-distributed.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '>= 12.3.3' # CVE-2020-8130
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'timecop'

--- a/money-distributed.gemspec
+++ b/money-distributed.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'rake', '>= 12.3.3' # CVE-2020-8130
+  spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'timecop'

--- a/money-distributed.gemspec
+++ b/money-distributed.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/DarthSim/money-distributed'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '~> 2.5' # rubocop:disable Gemspec/RequiredRubyVersion
+  spec.required_ruby_version = '>= 2.5' # rubocop:disable Gemspec/RequiredRubyVersion
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
* require rake >= 12.3.3 which addresses [CVE-2020-8130](https://github.com/advisories/GHSA-jppv-gw3r-w3q8)
* relax Ruby version requirement to allow upgrading to Ruby 3
* add Ruby 3.0 to CI

running the specs locally under Ruby 3.0: `10 examples, 0 failures` ✅ 