### PR TITLE
Shift Ruby Support (CI): drop 2, all of 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,19 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [2.6, 2.7, 3.0]
-        redis-version: [4, 5, 6]
+        ruby:
+          - 3.0
+          - 3.1
+          - 3.2
+          - head
+        redis-version:
+          - 5
+          - 6
+          - 7
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
@@ -17,11 +24,11 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
 
       - name: Set up Redis ${{ matrix.redis-version }}
-        uses: supercharge/redis-github-action@1.1.0
+        uses: supercharge/redis-github-action@1.5.0
         with:
           redis-version: ${{ matrix.redis-version }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.redis-version }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![CI](https://github.com/swiknaba/money-distributed/workflows/CI/badge.svg)
 
 # money-distributed
+
 Money gem extension for distributed systems
 
 <hr />
@@ -26,7 +27,7 @@ There is a gem available for OXR: https://github.com/spk/money-open-exchange-rat
 redis = Redis.new(url: ENV.fetch('REDIS_URL') { 'redis://localhost:6379/1' })
 store = Money::Distributed::Storage.new(redis)
 
-# we fetch rates from Open Exchange Rates: 
+# we fetch rates from Open Exchange Rates:
 oxr = Money::Bank::OpenExchangeRatesBank.new(store)
 oxr.app_id = Rails.application.credentials.dig(:oxr, :api_key)
 
@@ -41,6 +42,7 @@ Money.default_bank = oxr
 ```
 
 The mentioned worker:
+
 ```ruby
 # app/workers/money_update_rates_worker.rb
 
@@ -53,12 +55,14 @@ class MoneyUpdateRatesWorker
   end
 end
 ```
+
 You might want to set up a cron job to trigger this worker regularly.
 Set the schedule to a shorter time-window than the configured TTL of the exchange rates.
 This avoids, that rates are expired and have to be fetched from remote during a request.
 
 
 You probably want to install the following gems:
+
 ```ruby
 # Gemfile
 


### PR DESCRIPTION
* drop support for Ruby 2 (all 2.x are EOL by now)
* add all latest Ruby versions to test matrix
* drop Redis 4, add Redis 7